### PR TITLE
Update conda-forge.yml to include automerge

### DIFF
--- a/conda-forge.yml
+++ b/conda-forge.yml
@@ -4,3 +4,5 @@ github:
 conda_build:
   error_overlinking: true
 conda_forge_output_validation: true
+bot:
+  automerge: true


### PR DESCRIPTION
This PR enables the regro-bot automerge in `conda-forge.yml`.

- No recipe changes.
- No version change.
- No build number change required.

@conda-forge-admin, please rerender
